### PR TITLE
Add venv-manager skill for consistent Python environment organization

### DIFF
--- a/skills/gitingest/SKILL.md
+++ b/skills/gitingest/SKILL.md
@@ -41,9 +41,12 @@ If gitingest is not found, ask the user how they'd like to install it:
 
 **Options:**
 - **Specify path** - User provides path to existing venv or installation
-- **Create a venv for me** - Convenience option: look up the venv-manager skill by name/description and use it to create a venv and install the package
+- **Create a venv for me** - Convenience option: look up the venv-manager skill and follow its conventions
 
-If user chooses the convenience option, discover and invoke a venv-manager skill to handle the installation. Do not hardcode venv paths - let the venv-manager skill decide the organization.
+If user chooses the convenience option:
+1. Look for a venv-manager skill by name/description
+2. If found, follow its conventions to create the venv and install the package
+3. If NOT found, inform the user: "The venv-manager skill isn't available. Would you like to specify a path manually, or should I create a venv at ~/.venvs/gitingest/?"
 
 ### 3. Identify the Target
 

--- a/skills/venv-manager/SKILL.md
+++ b/skills/venv-manager/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: venv-manager
+description: Manage Python virtual environments in a consistent, organized way. Use when a skill needs Python packages installed, or when the user wants to create a venv following standard conventions. Provides the authoritative convention for venv location and naming that other skills should follow.
+---
+
+# Venv Manager
+
+Provides standardized conventions and commands for managing Python virtual environments. Other skills that need Python packages should reference this skill to ensure consistent organization.
+
+## Convention
+
+All virtual environments are stored in a standard location with consistent naming:
+
+```
+~/.venvs/<package-name>/
+```
+
+**Examples:**
+- `~/.venvs/gitingest/`
+- `~/.venvs/docetl/`
+- `~/.venvs/myproject/`
+
+## When to Use
+
+- Another skill needs a Python package installed
+- User wants to create a venv following standard conventions
+- User asks about venv organization or where venvs are stored
+
+## Workflow
+
+### 1. Check if Venv Already Exists
+
+Before creating, check if the venv already exists:
+
+```bash
+ls ~/.venvs/<name>/bin/python 2>/dev/null && echo "EXISTS" || echo "NOT_FOUND"
+```
+
+### 2. Create a New Venv
+
+```bash
+python3 -m venv ~/.venvs/<name>
+```
+
+### 3. Install Packages
+
+Install one or more packages into the venv:
+
+```bash
+~/.venvs/<name>/bin/pip install <package1> <package2> ...
+```
+
+### 4. Run Commands in the Venv
+
+To run a command using the venv's Python or installed packages:
+
+```bash
+~/.venvs/<name>/bin/<command> <args>
+```
+
+Or activate first (less preferred):
+
+```bash
+source ~/.venvs/<name>/bin/activate
+<command> <args>
+deactivate
+```
+
+## Complete Example
+
+Creating a venv for gitingest:
+
+```bash
+# Check if exists
+ls ~/.venvs/gitingest/bin/python 2>/dev/null && echo "EXISTS" || echo "NOT_FOUND"
+
+# Create venv (if NOT_FOUND)
+python3 -m venv ~/.venvs/gitingest
+
+# Install package
+~/.venvs/gitingest/bin/pip install gitingest
+
+# Verify installation
+~/.venvs/gitingest/bin/gitingest --version
+
+# Use it
+~/.venvs/gitingest/bin/gitingest https://github.com/owner/repo -o output.txt
+```
+
+## For Other Skills
+
+If you're a skill that needs Python packages:
+
+1. Ask the user how they want to install the package
+2. If user chooses "create a venv for me", follow the conventions in this skill
+3. Use `~/.venvs/<package-name>/` as the location
+4. Run commands via `~/.venvs/<package-name>/bin/<command>`
+
+## Listing Existing Venvs
+
+To see what venvs exist:
+
+```bash
+ls -1 ~/.venvs/
+```
+
+## Removing a Venv
+
+To remove a venv (requires user confirmation):
+
+```bash
+rm -rf ~/.venvs/<name>
+```
+
+**Always confirm with user before deleting.**


### PR DESCRIPTION
## Summary

- Adds venv-manager skill that defines conventions for Python virtual environments
- Convention: `~/.venvs/<package-name>/`
- Provides commands for creating, installing, and using venvs
- Acts as authoritative reference that other skills can follow
- Updates gitingest skill with fallback behavior when venv-manager not found

## Design

The venv-manager skill is a **reference** - it defines the organizational conventions that other skills should follow. Skills don't programmatically invoke it; they read it and follow its guidance.

This ensures:
- Consistent venv organization across all skills
- Single source of truth for conventions
- Easy to update conventions in one place

## Test plan

- [x] venv-manager skill defines clear conventions
- [x] gitingest skill updated with fallback behavior
- [ ] Test gitingest with venv-manager available

Closes #4